### PR TITLE
Use MOD_USER_FILES_DIR environment variable if present for record destination

### DIFF
--- a/screcord/screcord1.cc
+++ b/screcord/screcord1.cc
@@ -140,7 +140,9 @@ inline std::string SCapture::get_ffilename() {
         pPath +="/lv2record/";
     }
 #else
-    pPath = "/data/user-files/Audio Recordings/lv2record/";
+    const char *Path = getenv("MOD_USER_FILES_DIR");
+    pPath = Path ? Path : "/data/user-files";
+    pPath += "/Audio Recordings/lv2record/";
 #endif
     is_wav = int(*fformat) ? false : true;
     if (!(stat(pPath.c_str(), &sb) == 0 && S_ISDIR(sb.st_mode))) {


### PR DESCRIPTION
On MODEP, we set a couple of environment variables to set the paths for MOD software (most of the variables are defined in [settings.py](https://github.com/BlokasLabs/mod-ui/blob/modep-1.12-ps/mod/settings.py)), so the changes in this pull request first tries to read the MOD_USER_FILES_DIR and use that, if its not present, it falls back to the old path.